### PR TITLE
Changed K8S deployment type and Terraform K8S provider error

### DIFF
--- a/Student/Resources/terraform/k8prod.tf
+++ b/Student/Resources/terraform/k8prod.tf
@@ -1,8 +1,11 @@
 provider "kubernetes" {
 
   host                   = "${azurerm_kubernetes_cluster.akscluster.kube_config.0.host}"
-  username               = "${azurerm_kubernetes_cluster.akscluster.kube_config.0.username}"
-  password               = "${azurerm_kubernetes_cluster.akscluster.kube_config.0.password}"
+  #
+  # BC - Removed these as per github issue https://github.com/terraform-providers/terraform-provider-kubernetes/issues/175
+  #
+  #username               = "${azurerm_kubernetes_cluster.akscluster.kube_config.0.username}"
+  #password               = "${azurerm_kubernetes_cluster.akscluster.kube_config.0.password}"
   client_certificate     = "${base64decode(azurerm_kubernetes_cluster.akscluster.kube_config.0.client_certificate)}"
   client_key             = "${base64decode(azurerm_kubernetes_cluster.akscluster.kube_config.0.client_key)}"
   cluster_ca_certificate = "${base64decode(azurerm_kubernetes_cluster.akscluster.kube_config.0.cluster_ca_certificate)}"
@@ -15,7 +18,10 @@ resource "kubernetes_namespace" "example" {
   }
 }
 
-resource "kubernetes_pod" "web" {
+#
+# BC - Changed to 'deployment' rather than a 'pod'
+#
+resource "kubernetes_deployment" "web" {
   metadata {
     name = "nginx"
 
@@ -27,9 +33,27 @@ resource "kubernetes_pod" "web" {
   }
 
   spec {
-    container {
-      image = "nginx:1.7.9"
-      name  = "nginx"
+    replicas = 1
+
+    selector {
+      match_labels {
+        name = "nginx"
+      }
+    }
+
+    template {
+      metadata {
+        labels {
+          name = "nginx"
+        }
+      }
+
+      spec {
+        container {
+          image = "nginx:1.7.9"
+          name  = "nginx"
+        }
+      }
     }
   }
 }
@@ -42,7 +66,7 @@ resource "kubernetes_service" "web" {
 
   spec {
     selector {
-      name = "${kubernetes_pod.web.metadata.0.labels.name}"
+      name = "${kubernetes_deployment.web.metadata.0.labels.name}"
     }
 
     session_affinity = "ClientIP"


### PR DESCRIPTION
This is a modified k8prod.tf with two changes

I received errors when applying my Terraform plan
```
Error: Error applying plan:

1 error(s) occurred:

* provider.kubernetes: Failed to configure: username/password or bearer token may be set, but not both
``` 
I removed the username & password, as they are not used to connect to the cluster (AKS doesn't set up password auth) and the error went away

Second change was to deploy the nginx workload via a Deployment rather than a bare Pod. It's bad practice to deploy Pods directly, even if you only want one, the end result is more or less the same